### PR TITLE
Use outFile option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ class SassPlugin {
           if(err) {
             compilation.errors.push(wrapError(err));
           } else {
-            compilation.assets[fileName] = toAsset(result);
+            compilation.assets[options.outFile || fileName] = toAsset(result);
             audit.track(result.stats);
           }
           cb();


### PR DESCRIPTION
Just a little correction to be able to use the 'outFile' option to stablish a different output filename for the compiled result.